### PR TITLE
AttachmentModal url check is now case insensitive

### DIFF
--- a/src/components/Modals/AttachmentModal.svelte
+++ b/src/components/Modals/AttachmentModal.svelte
@@ -54,7 +54,7 @@
 			.string()
 			.url("Invalid URL")
 			.test("image-url", "URL must point to an image", (url) => {
-				return url.match(/\.(jpeg|jpg|gif|png)$/) != null
+				return url.toLowerCase().match(/\.(jpeg|jpg|gif|png)$/) != null
 			})
 			.required("URL is a required field"),
 		note: yup


### PR DESCRIPTION
Closes #11 

The URL being compared is now converted to lower case before regex pattern match.